### PR TITLE
Update deployment target to iOS 10

### DIFF
--- a/LzmaSDK-ObjC.podspec
+++ b/LzmaSDK-ObjC.podspec
@@ -36,7 +36,7 @@ The main advantages is:
   s.source           = { :git => "https://github.com/OlehKulykov/LzmaSDKObjC.git", :tag => s.version.to_s }
 
 # Platforms
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = "10.0"
   s.tvos.deployment_target = "10.0"
   s.osx.deployment_target = "10.9"
 


### PR DESCRIPTION
This pull request resolves an Xcode 12 warning of a deployment target below iOS 10.